### PR TITLE
Update workflow to include permissions for write access

### DIFF
--- a/.github/workflows/build-and-review-pr.yml
+++ b/.github/workflows/build-and-review-pr.yml
@@ -21,6 +21,10 @@ on:
   #   without disabling that requirement.  If we have a status check that is always produced,
   #   we can also use that to require all branches be up to date before they are merged.
 
+permissions:
+  contents: write
+  pull-requests: write
+  
 jobs:
   build-and-review-pr:
     # This reusable workflow will check to see if an action's source code has changed based on


### PR DESCRIPTION
## Summary of PR changes

This PR adds explicit permissions configuration to the build-and-review-pr.yml workflow to grant write access to contents and pull-requests.

## Why this change is needed:

The workflow uses the pull_request trigger which, by default, provides the GITHUB_TOKEN with read-only permissions for security reasons
The test job needs to create releases during testing, which requires contents: write permission
Without these permissions, the tests fail with "Resource not accessible by integration" errors when attempting to create test releases

## Changes made:

Added workflow-level permissions block granting contents: write and pull-requests: write
This ensures the test job can successfully create and delete releases during the test execution
No changes to action source code, only to the workflow configuration
This is a workflow configuration change only and does not affect the action's functionality or require version incrementing.

## PR Requirements
 For major, minor, or breaking changes, at least one of the commit messages contains the appropriate +semver: keywords.
See the Incrementing the Version section of the repository's README.md for more details.
N/A - This PR only modifies workflow configuration under .github/workflows/, not source code
 The action code does not contain sensitive information.
NOTE: If the repo's workflow could not automatically update the README.md, it should be updated manually with the next version. For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.

Note: Per the [Source Code Changes](https://github.com/im-open/upload-release-asset#source-code-changes) section of the README, changes to workflows under ./.github/workflows do not require version updates or recompilation.